### PR TITLE
refactor: merge DebouncedInput into TextFilter component

### DIFF
--- a/src/components/Author/Filters.tsx
+++ b/src/components/Author/Filters.tsx
@@ -1,6 +1,6 @@
-import { DebouncedInput } from "~/components/DebouncedInput";
 import { SelectField } from "~/components/SelectField";
 import { SelectOptions } from "~/components/SelectOptions";
+import { TextFilter } from "~/components/TextFilter";
 import { YearInput } from "~/components/YearInput";
 
 import type { ActionType, Sort } from "./Author.reducer";
@@ -20,7 +20,7 @@ export function Filters({
 }) {
   return (
     <>
-      <DebouncedInput
+      <TextFilter
         label="Title"
         onInputChange={(value) =>
           dispatch({ type: Actions.FILTER_TITLE, value })

--- a/src/components/Authors/Filters.tsx
+++ b/src/components/Authors/Filters.tsx
@@ -1,5 +1,5 @@
-import { DebouncedInput } from "~/components/DebouncedInput";
 import { SelectField } from "~/components/SelectField";
+import { TextFilter } from "~/components/TextFilter";
 
 import type { ActionType, Sort } from "./Authors.reducer";
 
@@ -14,7 +14,7 @@ export function Filters({
 }) {
   return (
     <>
-      <DebouncedInput
+      <TextFilter
         label="Name"
         onInputChange={(value) =>
           dispatch({ type: Actions.FILTER_NAME, value })

--- a/src/components/Readings/Filters.tsx
+++ b/src/components/Readings/Filters.tsx
@@ -1,8 +1,8 @@
 import type { JSX } from "react";
 
-import { DebouncedInput } from "~/components/DebouncedInput";
 import { SelectField } from "~/components/SelectField";
 import { SelectOptions } from "~/components/SelectOptions";
+import { TextFilter } from "~/components/TextFilter";
 import { YearInput } from "~/components/YearInput";
 
 import type { ActionType, Sort } from "./Readings.reducer";
@@ -26,7 +26,7 @@ export function Filters({
 }): JSX.Element {
   return (
     <>
-      <DebouncedInput
+      <TextFilter
         label="Title"
         onInputChange={(value) =>
           dispatch({ type: Actions.FILTER_TITLE, value })

--- a/src/components/Reviews/Filters.tsx
+++ b/src/components/Reviews/Filters.tsx
@@ -1,6 +1,6 @@
-import { DebouncedInput } from "~/components/DebouncedInput";
 import { SelectField } from "~/components/SelectField";
 import { SelectOptions } from "~/components/SelectOptions";
+import { TextFilter } from "~/components/TextFilter";
 import { YearInput } from "~/components/YearInput";
 
 import type { ActionType, Sort } from "./Reviews.reducer";
@@ -22,7 +22,7 @@ export function Filters({
 }) {
   return (
     <>
-      <DebouncedInput
+      <TextFilter
         label="Title"
         onInputChange={(value) =>
           dispatch({ type: Actions.FILTER_TITLE, value })

--- a/src/components/TextFilter.tsx
+++ b/src/components/TextFilter.tsx
@@ -8,7 +8,7 @@ import { debounce } from "~/utils/debounce";
 
 import { LabelText } from "./LabelText";
 
-export function DebouncedInput({
+export function TextFilter({
   label,
   onInputChange,
   placeholder,


### PR DESCRIPTION
## Summary
- Renamed `DebouncedInput` component to `TextFilter` for better semantic clarity
- Consolidated component since it was only used for text filtering in Filter components
- Updated all 4 Filter component imports (Reviews, Readings, Author, Authors)

## Test plan
✅ All tests pass (`npm test`)
✅ Linting passes (`npm run lint`)
✅ Type checking passes (`npm run check`)
✅ No unused dependencies (`npm run knip`)
✅ Formatting is correct (`npm run format`)
✅ Spelling check passes (`npm run lint:spelling`)

🤖 Generated with [Claude Code](https://claude.ai/code)