### PR TITLE
feat: add drop caps to article opening paragraphs

### DIFF
--- a/DESIGN_IDEAS.md
+++ b/DESIGN_IDEAS.md
@@ -9,7 +9,7 @@
 ## Typography & Readability
 
 - [x] Increase contrast on secondary text (dates, metadata) for better accessibility
-- [ ] Add drop caps to review opening paragraphs for visual interest
+- [x] Add drop caps to review opening paragraphs for visual interest
 - [ ] Implement better quote styling with larger pull quotes for memorable passages
 
 ## Interactive Elements

--- a/src/components/Article/Article.tsx
+++ b/src/components/Article/Article.tsx
@@ -35,7 +35,21 @@ export function Article({
         />
         <section className="flex flex-col items-center pt-16 pb-32">
           <div className="px-container">
-            <LongFormText className="max-w-prose" text={content} />
+            <LongFormText
+              className={`
+                max-w-prose
+                first-letter:leading-[.8] first-letter:text-default
+                tablet:first-letter:pr-3
+                desktop:first-letter:text-[64px]
+                [&>p:first-child]:first-letter:float-left
+                [&>p:first-child]:first-letter:mt-[6px]
+                [&>p:first-child]:first-letter:pr-2
+                [&>p:first-child]:first-letter:font-sans
+                [&>p:first-child]:first-letter:text-[56px]
+                [&>p:first-child]:first-letter:font-bold
+              `}
+              text={content}
+            />
           </div>
         </section>
       </article>

--- a/src/pages/404/__snapshots__/index.html
+++ b/src/pages/404/__snapshots__/index.html
@@ -255,7 +255,7 @@
             <section class="flex flex-col items-center pt-16 pb-32">
               <div class="px-container">
                 <div
-                  class="rendered-markdown text-md/7 tracking-[0.3px] tablet:text-xl/8 max-w-prose"
+                  class="rendered-markdown text-md/7 tracking-[0.3px] tablet:text-xl/8 max-w-prose first-letter:leading-[.8] first-letter:text-default tablet:first-letter:pr-3 desktop:first-letter:text-[64px] [&amp;&gt;p:first-child]:first-letter:float-left [&amp;&gt;p:first-child]:first-letter:mt-[6px] [&amp;&gt;p:first-child]:first-letter:pr-2 [&amp;&gt;p:first-child]:first-letter:font-sans [&amp;&gt;p:first-child]:first-letter:text-[56px] [&amp;&gt;p:first-child]:first-letter:font-bold"
                 >
                   <p>My apologies.</p>
                 </div>

--- a/src/pages/gone/__snapshots__/index.html
+++ b/src/pages/gone/__snapshots__/index.html
@@ -258,7 +258,7 @@
             <section class="flex flex-col items-center pt-16 pb-32">
               <div class="px-container">
                 <div
-                  class="rendered-markdown text-md/7 tracking-[0.3px] tablet:text-xl/8 max-w-prose"
+                  class="rendered-markdown text-md/7 tracking-[0.3px] tablet:text-xl/8 max-w-prose first-letter:leading-[.8] first-letter:text-default tablet:first-letter:pr-3 desktop:first-letter:text-[64px] [&amp;&gt;p:first-child]:first-letter:float-left [&amp;&gt;p:first-child]:first-letter:mt-[6px] [&amp;&gt;p:first-child]:first-letter:pr-2 [&amp;&gt;p:first-child]:first-letter:font-sans [&amp;&gt;p:first-child]:first-letter:text-[56px] [&amp;&gt;p:first-child]:first-letter:font-bold"
                 >
                   <p>Whatever you’re looking for, it’s not coming back.</p>
                 </div>

--- a/src/pages/how-i-grade/__snapshots__/index.html
+++ b/src/pages/how-i-grade/__snapshots__/index.html
@@ -274,7 +274,7 @@
               <section class="flex flex-col items-center pt-16 pb-32">
                 <div class="px-container">
                   <div
-                    class="rendered-markdown text-md/7 tracking-[0.3px] tablet:text-xl/8 max-w-prose"
+                    class="rendered-markdown text-md/7 tracking-[0.3px] tablet:text-xl/8 max-w-prose first-letter:leading-[.8] first-letter:text-default tablet:first-letter:pr-3 desktop:first-letter:text-[64px] [&amp;&gt;p:first-child]:first-letter:float-left [&amp;&gt;p:first-child]:first-letter:mt-[6px] [&amp;&gt;p:first-child]:first-letter:pr-2 [&amp;&gt;p:first-child]:first-letter:font-sans [&amp;&gt;p:first-child]:first-letter:text-[56px] [&amp;&gt;p:first-child]:first-letter:font-bold"
                   >
                     <p>
                       I apply the following criteria to both long and short form


### PR DESCRIPTION
## Summary
- Added drop caps styling to Article components to match the existing Review component styling
- Updated test snapshots for affected pages (404, gone, how-i-grade)
- Marked drop caps task as complete in DESIGN_IDEAS.md

## Test plan
- [x] All tests pass (`npm test`)
- [x] ESLint passes (`npm run lint`)
- [x] Spelling check passes (`npm run lint:spelling`) 
- [x] Astro type checking passes (`npm run check`)
- [x] No unused dependencies (`npm run knip`)
- [x] Formatting check passes (`npm run format`)
- [ ] Visual verification: Drop caps appear correctly on article pages

🤖 Generated with [Claude Code](https://claude.ai/code)