### PR TITLE
chore: mark book spine design as won't implement

### DIFF
--- a/DESIGN_IDEAS.md
+++ b/DESIGN_IDEAS.md
@@ -4,7 +4,7 @@
 
 - [ ] Implement a featured review carousel or hero section for standout reviews
 - [ ] Add reading progress indicators or visual badges for book categories/genres
-- [ ] Add book spine designs as decorative elements between sections
+- [x] ~~Add book spine designs as decorative elements between sections~~ (Won't implement - doesn't fit site aesthetic)
 
 ## Typography & Readability
 


### PR DESCRIPTION
## Summary
- Marked the book spine design idea as "won't implement" in DESIGN_IDEAS.md
- Added explanation that the design doesn't fit the site's clean aesthetic

## Context
After implementing and testing the book spine divider design, it was determined that it doesn't align with the site's minimalist aesthetic. This update documents that decision to avoid future attempts at the same feature.

🤖 Generated with [Claude Code](https://claude.ai/code)