### PR TITLE
Remove close filter delay for improved responsiveness

### DIFF
--- a/src/components/ListWithFilters/ListWithFilters.testHelper.ts
+++ b/src/components/ListWithFilters/ListWithFilters.testHelper.ts
@@ -1,9 +1,6 @@
 import type { UserEvent } from "@testing-library/user-event";
 
-import { act, screen } from "@testing-library/react";
-import { vi } from "vitest";
-
-import { DRAWER_CLOSE_ANIMATION_MS } from "./ListWithFilters";
+import { screen } from "@testing-library/react";
 
 export async function clickClearFilters(user: UserEvent) {
   return user.click(screen.getByRole("button", { name: "Clear all filters" }));
@@ -12,11 +9,6 @@ export async function clickClearFilters(user: UserEvent) {
 export async function clickCloseFilters(user: UserEvent) {
   // Close the drawer with the X button (should reset pending changes)
   await user.click(screen.getByRole("button", { name: "Close filters" }));
-
-  // Wait for drawer close animation
-  act(() => {
-    vi.advanceTimersByTime(DRAWER_CLOSE_ANIMATION_MS);
-  });
 }
 
 export async function clickSortOption(user: UserEvent, sortText: string) {
@@ -29,8 +21,4 @@ export async function clickToggleFilters(user: UserEvent) {
 
 export async function clickViewResults(user: UserEvent) {
   await user.click(screen.getByRole("button", { name: /View \d+ Results/ }));
-  // Wait for drawer close animation
-  act(() => {
-    vi.advanceTimersByTime(DRAWER_CLOSE_ANIMATION_MS);
-  });
 }

--- a/src/components/ListWithFilters/ListWithFilters.tsx
+++ b/src/components/ListWithFilters/ListWithFilters.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-export const DRAWER_CLOSE_ANIMATION_MS = 250;
 const DRAWER_OPEN_ANIMATION_MS = 400;
 
 type Props<T extends string> = {
@@ -72,7 +71,6 @@ export function ListWithFilters<T extends string>({
   totalCount,
 }: Props<T>): React.JSX.Element {
   const [filterDrawerVisible, setFilterDrawerVisible] = useState(false);
-  const [isClosing, setIsClosing] = useState(false);
   const [isOpening, setIsOpening] = useState(false);
   const filtersRef = useRef<HTMLDivElement | null>(null);
   const toggleButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -81,20 +79,13 @@ export function ListWithFilters<T extends string>({
 
   const handleCloseDrawer = useCallback(
     (shouldResetFilters = true) => {
-      setIsClosing(true);
-      // Start the spin animation, then close after a short delay
-      const timeoutId = setTimeout(() => {
-        if (typeof document !== "undefined") {
-          document.body.classList.remove("overflow-hidden");
-        }
-        setFilterDrawerVisible(false);
-        setIsClosing(false);
-        if (shouldResetFilters) {
-          onResetFilters?.();
-        }
-        timeoutRefs.current.delete(timeoutId);
-      }, DRAWER_CLOSE_ANIMATION_MS);
-      timeoutRefs.current.add(timeoutId);
+      if (typeof document !== "undefined") {
+        document.body.classList.remove("overflow-hidden");
+      }
+      setFilterDrawerVisible(false);
+      if (shouldResetFilters) {
+        onResetFilters?.();
+      }
     },
     [onResetFilters],
   );
@@ -142,7 +133,7 @@ export function ListWithFilters<T extends string>({
   // Handle escape key
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent): void => {
-      if (e.key === "Escape" && filterDrawerVisible && !isClosing) {
+      if (e.key === "Escape" && filterDrawerVisible) {
         handleCloseDrawer();
         toggleButtonRef.current?.focus();
       }
@@ -150,7 +141,7 @@ export function ListWithFilters<T extends string>({
 
     document.addEventListener("keydown", handleKeyDown);
     return (): void => document.removeEventListener("keydown", handleKeyDown);
-  }, [filterDrawerVisible, handleCloseDrawer, isClosing]);
+  }, [filterDrawerVisible, handleCloseDrawer]);
 
   // Scroll to top of list when sort changes
   useEffect(() => {
@@ -219,9 +210,7 @@ export function ListWithFilters<T extends string>({
               }
             `}
             onClick={() => {
-              if (!isClosing) {
-                handleCloseDrawer();
-              }
+              handleCloseDrawer();
             }}
           />
 
@@ -259,13 +248,10 @@ export function ListWithFilters<T extends string>({
                   cursor-pointer items-center justify-center rounded-full
                   bg-canvas text-default drop-shadow-sm transition-transform
                   hover:scale-105 hover:drop-shadow-md
-                  ${isClosing ? "pointer-events-none" : ""}
                 `}
                 onClick={() => {
-                  if (!isClosing) {
-                    handleCloseDrawer();
-                    toggleButtonRef.current?.focus();
-                  }
+                  handleCloseDrawer();
+                  toggleButtonRef.current?.focus();
                 }}
                 type="button"
               >
@@ -273,7 +259,6 @@ export function ListWithFilters<T extends string>({
                   aria-hidden="true"
                   className={`
                     h-4 w-4 transform-gpu
-                    ${isClosing ? "animate-spin-recoil" : ""}
                     ${isOpening ? "animate-spin-wind-up" : ""}
                   `}
                   fill="none"

--- a/src/components/ListWithFilters/__snapshots__/ListWithFilters.spec.tsx.snap
+++ b/src/components/ListWithFilters/__snapshots__/ListWithFilters.spec.tsx.snap
@@ -26,7 +26,6 @@ exports[`ListWithFilters > filter drawer > opens and closes filter drawer 1`] = 
                   cursor-pointer items-center justify-center rounded-full
                   bg-canvas text-default drop-shadow-sm transition-transform
                   hover:scale-105 hover:drop-shadow-md
-                  
                 "
       type="button"
     >
@@ -34,7 +33,6 @@ exports[`ListWithFilters > filter drawer > opens and closes filter drawer 1`] = 
         aria-hidden="true"
         class="
                     h-4 w-4 transform-gpu
-                    
                     
                   "
         fill="none"
@@ -153,7 +151,6 @@ exports[`ListWithFilters > filter drawer > opens and closes filter drawer 2`] = 
                   cursor-pointer items-center justify-center rounded-full
                   bg-canvas text-default drop-shadow-sm transition-transform
                   hover:scale-105 hover:drop-shadow-md
-                  
                 "
       type="button"
     >
@@ -161,7 +158,6 @@ exports[`ListWithFilters > filter drawer > opens and closes filter drawer 2`] = 
         aria-hidden="true"
         class="
                     h-4 w-4 transform-gpu
-                    
                     animate-spin-wind-up
                   "
         fill="none"
@@ -403,7 +399,6 @@ exports[`ListWithFilters > renders 1`] = `
                   cursor-pointer items-center justify-center rounded-full
                   bg-canvas text-default drop-shadow-sm transition-transform
                   hover:scale-105 hover:drop-shadow-md
-                  
                 "
               type="button"
             >
@@ -411,7 +406,6 @@ exports[`ListWithFilters > renders 1`] = `
                 aria-hidden="true"
                 class="
                     h-4 w-4 transform-gpu
-                    
                     
                   "
                 fill="none"

--- a/src/components/ListWithFilters/testUtils.ts
+++ b/src/components/ListWithFilters/testUtils.ts
@@ -1,9 +1,6 @@
 import type { UserEvent } from "@testing-library/user-event";
 
-import { act, screen } from "@testing-library/react";
-import { vi } from "vitest";
-
-import { DRAWER_CLOSE_ANIMATION_MS } from "./ListWithFilters";
+import { screen } from "@testing-library/react";
 
 export async function clickClearFilters(user: UserEvent) {
   return user.click(screen.getByRole("button", { name: "Clear all filters" }));
@@ -12,11 +9,6 @@ export async function clickClearFilters(user: UserEvent) {
 export async function clickCloseFilters(user: UserEvent) {
   // Close the drawer with the X button (should reset pending changes)
   await user.click(screen.getByRole("button", { name: "Close filters" }));
-
-  // Wait for drawer close animation
-  act(() => {
-    vi.advanceTimersByTime(DRAWER_CLOSE_ANIMATION_MS);
-  });
 }
 
 export async function clickToggleFilters(user: UserEvent) {
@@ -25,8 +17,4 @@ export async function clickToggleFilters(user: UserEvent) {
 
 export async function clickViewResults(user: UserEvent) {
   await user.click(screen.getByRole("button", { name: /View \d+ Results/ }));
-  // Wait for drawer close animation
-  act(() => {
-    vi.advanceTimersByTime(DRAWER_CLOSE_ANIMATION_MS);
-  });
 }

--- a/src/components/Readings/__snapshots__/Readings.spec.tsx.snap
+++ b/src/components/Readings/__snapshots__/Readings.spec.tsx.snap
@@ -19119,7 +19119,6 @@ exports[`Readings > renders 1`] = `
                   cursor-pointer items-center justify-center rounded-full
                   bg-canvas text-default drop-shadow-sm transition-transform
                   hover:scale-105 hover:drop-shadow-md
-                  
                 "
               type="button"
             >
@@ -19127,7 +19126,6 @@ exports[`Readings > renders 1`] = `
                 aria-hidden="true"
                 class="
                     h-4 w-4 transform-gpu
-                    
                     
                   "
                 fill="none"

--- a/src/components/Reviews/__snapshots__/Reviews.spec.tsx.snap
+++ b/src/components/Reviews/__snapshots__/Reviews.spec.tsx.snap
@@ -77145,7 +77145,6 @@ exports[`Reviews > renders 1`] = `
                   cursor-pointer items-center justify-center rounded-full
                   bg-canvas text-default drop-shadow-sm transition-transform
                   hover:scale-105 hover:drop-shadow-md
-                  
                 "
               type="button"
             >
@@ -77153,7 +77152,6 @@ exports[`Reviews > renders 1`] = `
                 aria-hidden="true"
                 class="
                     h-4 w-4 transform-gpu
-                    
                     
                   "
                 fill="none"

--- a/src/pages/authors/[slug]/__snapshots__/jesse-itzler.html
+++ b/src/pages/authors/[slug]/__snapshots__/jesse-itzler.html
@@ -505,7 +505,7 @@
             </div>
           </header>
           <astro-island
-            uid="1CATp"
+            uid="2bmrY7"
             prefix="r3"
             component-url="~/components/Author/Author"
             component-export="Author"

--- a/src/pages/authors/[slug]/__snapshots__/richard-laymon.html
+++ b/src/pages/authors/[slug]/__snapshots__/richard-laymon.html
@@ -527,7 +527,7 @@
             </div>
           </header>
           <astro-island
-            uid="2bRgLK"
+            uid="F5PWy"
             prefix="r3"
             component-url="~/components/Author/Author"
             component-export="Author"

--- a/src/pages/authors/[slug]/__snapshots__/stephen-king.html
+++ b/src/pages/authors/[slug]/__snapshots__/stephen-king.html
@@ -522,7 +522,7 @@
             </div>
           </header>
           <astro-island
-            uid="1Xsos6"
+            uid="Z19M4L7"
             prefix="r3"
             component-url="~/components/Author/Author"
             component-export="Author"

--- a/src/pages/authors/__snapshots__/index.html
+++ b/src/pages/authors/__snapshots__/index.html
@@ -495,7 +495,7 @@
             </div>
           </header>
           <astro-island
-            uid="Z1TXcAN"
+            uid="1nIJUR"
             prefix="r3"
             component-url="~/components/Authors/Authors"
             component-export="Authors"

--- a/src/pages/readings/__snapshots__/index.html
+++ b/src/pages/readings/__snapshots__/index.html
@@ -495,7 +495,7 @@
             </div>
           </header>
           <astro-island
-            uid="ZxMHVa"
+            uid="1Vbr9W"
             prefix="r3"
             component-url="~/components/Readings/Readings"
             component-export="Readings"

--- a/src/pages/reviews/__snapshots__/index.html
+++ b/src/pages/reviews/__snapshots__/index.html
@@ -495,7 +495,7 @@
             </div>
           </header>
           <astro-island
-            uid="Z1tlLrB"
+            uid="Z11ACSW"
             prefix="r3"
             component-url="~/components/Reviews/Reviews"
             component-export="Reviews"


### PR DESCRIPTION
## Summary

Removes the artificial 250ms delay when closing filters, making the filter drawer close immediately for improved user experience and responsiveness.

### Changes Made

- **Removed delay mechanism**: Deleted `DRAWER_CLOSE_ANIMATION_MS` constant and related setTimeout logic
- **Simplified close handler**: `handleCloseDrawer` now executes immediately without delay
- **Removed closing state**: Eliminated `isClosing` state and related conditional logic
- **Updated test helpers**: Removed delay-related code from test utility functions
- **Preserved opening animation**: Kept the opening animation for visual feedback while removing the closing delay
- **Updated snapshots**: Refreshed test snapshots to reflect the streamlined behavior

### Benefits

1. **Improved responsiveness**: Filters close instantly when clicked, eliminating the frustrating wait
2. **Better UX**: Users can quickly open/close filters without animation delays interrupting their workflow  
3. **Cleaner code**: Removed unnecessary timeout management and state complexity
4. **Consistent behavior**: Matches the implementation from the movie log project

### Test Plan

- [x] All existing tests pass with updated snapshots
- [x] Filter drawer closes immediately when clicking close button
- [x] Filter drawer closes immediately when clicking backdrop
- [x] Filter drawer closes immediately when pressing Escape key
- [x] Filter drawer closes immediately when clicking "View Results" button
- [x] Opening animation still works for visual feedback
- [x] ESLint, TypeScript, and formatting checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)